### PR TITLE
Updated Python version to 3 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:3
 
 LABEL maintainer="felixonta@gmail.com"
 


### PR DESCRIPTION
Updated Python version to 3 in Dockerfile.

We were using `andaluh-py` 0.1.2 due to the Python version 2.7